### PR TITLE
Use `default_client` in version 5

### DIFF
--- a/lib/mongoid_cleaner.rb
+++ b/lib/mongoid_cleaner.rb
@@ -29,7 +29,11 @@ module MongoidCleaner
     end
 
     def session
-      @session ||= Mongoid.default_session
+      @session ||= if mongoid_version > 4
+                     Mongoid.default_client
+                   else
+                     Mongoid.default_session
+                   end
     end
 
     # return with mongoid 5 `Mongo::Operation::Result`


### PR DESCRIPTION
Removes deprecation note:
```
NOTE: Mongoid.default_session is deprecated; use default_client instead. It will be removed on or after 2015-12-01.
Mongoid.default_session called from /Users/wojtek/.rvm/gems/ruby-2.2.3@attic_vw_wob/gems/mongoid_cleaner-1.1.0/lib/mongoid_cleaner.rb:32.
```